### PR TITLE
Add Help Bot component for basic user guidance

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,4 @@
+import HelpBot from "./components/HelpBot/HelpBot";
 import { Routes, Route } from 'react-router-dom'
 import BaseLayout from './layouts/BaseLayout'
 import Home from './pages/Home/Home'
@@ -7,39 +8,44 @@ import Showcase from './pages/Showcase/Showcase'
 
 export default function App() {
   return (
-    <Routes>
-      <Route
-        path="/"
-        element={
-          <BaseLayout title="OpenLife" subtitle="Daily Workflow & Time Management">
-            <Home />
-          </BaseLayout>
-        }
-      />
-      <Route
-        path="/about"
-        element={
-          <BaseLayout title="About OpenLife">
-            <About />
-          </BaseLayout>
-        }
-      />
-      <Route
-        path="/contribute"
-        element={
-          <BaseLayout title="Contribute to OpenLife">
-            <Contribute />
-          </BaseLayout>
-        }
-      />
-      <Route
-        path="/showcase"
-        element={
-          <BaseLayout title="OpenLife UI Showcase" subtitle="Reusable components and patterns">
-            <Showcase />
-          </BaseLayout>
-        }
-      />
-    </Routes>
+    <>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <BaseLayout title="OpenLife" subtitle="Daily Workflow & Time Management">
+              <Home />
+            </BaseLayout>
+          }
+        />
+        <Route
+          path="/about"
+          element={
+            <BaseLayout title="About OpenLife">
+              <About />
+            </BaseLayout>
+          }
+        />
+        <Route
+          path="/contribute"
+          element={
+            <BaseLayout title="Contribute to OpenLife">
+              <Contribute />
+            </BaseLayout>
+          }
+        />
+        <Route
+          path="/showcase"
+          element={
+            <BaseLayout title="OpenLife UI Showcase" subtitle="Reusable components and patterns">
+              <Showcase />
+            </BaseLayout>
+          }
+        />
+      </Routes>
+
+      {/* Global Help Bot */}
+      <HelpBot />
+    </>
   )
 }

--- a/frontend/src/components/HelpBot/HelpBot.jsx
+++ b/frontend/src/components/HelpBot/HelpBot.jsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+
+const HelpBot = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ position: "fixed", bottom: "20px", right: "20px" }}>
+      <button
+        onClick={() => setOpen(!open)}
+        style={{
+          width: "50px",
+          height: "50px",
+          borderRadius: "50%",
+          border: "none",
+          background: "#4f46e5",
+          color: "#fff",
+          fontSize: "20px",
+          cursor: "pointer"
+        }}
+      >
+        ?
+      </button>
+
+      {open && (
+        <div
+          style={{
+            marginTop: "10px",
+            background: "#fff",
+            padding: "10px",
+            width: "220px",
+            borderRadius: "8px",
+            boxShadow: "0 4px 10px rgba(0,0,0,0.1)"
+          }}
+        >
+          <strong>Need Help?</strong>
+          <ul style={{ fontSize: "14px", marginTop: "8px" }}>
+            <li>Track daily tasks</li>
+            <li>Use timer effectively</li>
+            <li>View daily summary</li>
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HelpBot;


### PR DESCRIPTION
Fixes #8 
<img width="1919" height="970" alt="Screenshot 2026-01-16 231654" src="https://github.com/user-attachments/assets/e81ce8c0-09b4-4bca-9d8e-4c7255fc2e88" />


### What’s added
- Added a floating Help Bot component accessible across all pages
- Help button opens a small guidance popup for users

### Screenshots
Attached screenshot showing the Help Bot popup in action.
