### PR TITLE
Add PATCH and DELETE endpoints with corresponding API tests

### DIFF
--- a/backend-dotnet/OpenLife.Api.Tests/ApiSmokeTests.cs
+++ b/backend-dotnet/OpenLife.Api.Tests/ApiSmokeTests.cs
@@ -41,7 +41,8 @@ public sealed class ApiSmokeTests : IClassFixture<WebApplicationFactory<Program>
             "Add a smoke test for the ASP.NET Core backend",
             "normal",
             "daily",
-            DateTimeOffset.UtcNow.AddDays(1));
+            DateTimeOffset.UtcNow.AddDays(1)
+        );
 
         var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
         Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
@@ -65,7 +66,8 @@ public sealed class ApiSmokeTests : IClassFixture<WebApplicationFactory<Program>
             "Description",
             "normal",
             "daily",
-            DateTimeOffset.UtcNow.AddDays(1));
+            DateTimeOffset.UtcNow.AddDays(1)
+        );
 
         var response = await _client.PostAsJsonAsync("/api/tasks", request);
 
@@ -73,39 +75,44 @@ public sealed class ApiSmokeTests : IClassFixture<WebApplicationFactory<Program>
     }
 
     [Fact]
-public async Task Task_endpoint_updates_task_successfully()
-{
-    // Step 1: Create task
-    var request = new CreateTaskRequest(
-        "Test Task",
-        "Test Description",
-        "normal",
-        "daily",
-        DateTimeOffset.UtcNow.AddDays(1));
+    public async Task Task_endpoint_updates_task_successfully()
+    {
+        // Step 1: Create task
+        var request = new CreateTaskRequest(
+            "Test Task",
+            "Test Description",
+            "normal",
+            "daily",
+            DateTimeOffset.UtcNow.AddDays(1)
+        );
 
-    var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
-    var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
-    Assert.NotNull(created);
+        var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
+        var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
+        Assert.NotNull(created);
 
-    // Step 2: Update task
-    var updateRequest = new CreateTaskRequest(
-        "Updated Task",
-        "Updated Description",
-        "high",
-        "weekly",
-        DateTimeOffset.UtcNow.AddDays(2));
+        // Step 2: Update task
+        var updateRequest = new CreateTaskRequest(
+            "Updated Task",
+            "Updated Description",
+            "high",
+            "weekly",
+            DateTimeOffset.UtcNow.AddDays(2)
+        );
 
-    var updateResponse = await _client.PatchAsJsonAsync($"/api/tasks/{created.Id}", updateRequest);
+        var updateResponse = await _client.PatchAsJsonAsync(
+            $"/api/tasks/{created.Id}",
+            updateRequest
+        );
 
-    // Step 3: Check result
-    Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+        // Step 3: Check result
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
 
-    var updated = await updateResponse.Content.ReadFromJsonAsync<TaskResponse>();
-    Assert.NotNull(updated);
-    Assert.Equal("Updated Task", updated.Title);
-}
+        var updated = await updateResponse.Content.ReadFromJsonAsync<TaskResponse>();
+        Assert.NotNull(updated);
+        Assert.Equal("Updated Task", updated.Title);
+    }
 
-[Fact]
+    [Fact]
     public async Task Task_endpoint_update_rejects_empty_title()
     {
         var request = new CreateTaskRequest(
@@ -113,7 +120,8 @@ public async Task Task_endpoint_updates_task_successfully()
             "Valid Description",
             "normal",
             "daily",
-            DateTimeOffset.UtcNow.AddDays(1));
+            DateTimeOffset.UtcNow.AddDays(1)
+        );
 
         var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
         var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
@@ -124,7 +132,8 @@ public async Task Task_endpoint_updates_task_successfully()
             "Updated Description",
             "normal",
             "daily",
-            DateTimeOffset.UtcNow.AddDays(1));
+            DateTimeOffset.UtcNow.AddDays(1)
+        );
 
         var response = await _client.PatchAsJsonAsync($"/api/tasks/{created.Id}", invalidUpdate);
 
@@ -139,7 +148,8 @@ public async Task Task_endpoint_updates_task_successfully()
             "Valid Description",
             "normal",
             "daily",
-            DateTimeOffset.UtcNow.AddDays(1));
+            DateTimeOffset.UtcNow.AddDays(1)
+        );
 
         var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
         var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
@@ -150,37 +160,61 @@ public async Task Task_endpoint_updates_task_successfully()
             "Updated Description",
             "wrong",
             "daily",
-            DateTimeOffset.UtcNow.AddDays(1));
+            DateTimeOffset.UtcNow.AddDays(1)
+        );
 
         var response = await _client.PatchAsJsonAsync($"/api/tasks/{created.Id}", invalidUpdate);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
+    [Fact]
+    public async Task Task_endpoint_deletes_task_successfully()
+    {
+        var request = new CreateTaskRequest(
+            "Test Task",
+            "Test Description",
+            "normal",
+            "daily",
+            DateTimeOffset.UtcNow.AddDays(1)
+        );
 
-[Fact]
-public async Task Task_endpoint_deletes_task_successfully()
-{
-    var request = new CreateTaskRequest(
-        "Test Task",
-        "Test Description",
-        "normal",
-        "daily",
-        DateTimeOffset.UtcNow.AddDays(1));
+        var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
+        var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
+        Assert.NotNull(created);
 
-    var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
-    var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
-    Assert.NotNull(created);
+        var deleteResponse = await _client.DeleteAsync($"/api/tasks/{created.Id}");
 
-    var deleteResponse = await _client.DeleteAsync($"/api/tasks/{created.Id}");
+        Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
 
-    Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+        var getResponse = await _client.GetAsync($"/api/tasks/{created.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
 
-    var getResponse = await _client.GetAsync($"/api/tasks/{created.Id}");
-    Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
-}
-    private sealed record HealthResponse(string Status, string Service, DateTimeOffset TimestampUtc);
+    private sealed record HealthResponse(
+        string Status,
+        string Service,
+        DateTimeOffset TimestampUtc
+    );
+
     private sealed record InfoResponse(string Name, string Backend, string Status, string Purpose);
-    private sealed record CreateTaskRequest(string Title, string Description, string Priority, string Period, DateTimeOffset DueDate);
-    private sealed record TaskResponse(Guid Id, string Title, string Description, string Status, string Priority, string Period, DateTimeOffset DueDate, DateTimeOffset CreatedAtUtc);
+
+    private sealed record CreateTaskRequest(
+        string Title,
+        string Description,
+        string Priority,
+        string Period,
+        DateTimeOffset DueDate
+    );
+
+    private sealed record TaskResponse(
+        Guid Id,
+        string Title,
+        string Description,
+        string Status,
+        string Priority,
+        string Period,
+        DateTimeOffset DueDate,
+        DateTimeOffset CreatedAtUtc
+    );
 }

--- a/backend-dotnet/OpenLife.Api.Tests/ApiSmokeTests.cs
+++ b/backend-dotnet/OpenLife.Api.Tests/ApiSmokeTests.cs
@@ -106,6 +106,59 @@ public async Task Task_endpoint_updates_task_successfully()
 }
 
 [Fact]
+    public async Task Task_endpoint_update_rejects_empty_title()
+    {
+        var request = new CreateTaskRequest(
+            "Valid Title",
+            "Valid Description",
+            "normal",
+            "daily",
+            DateTimeOffset.UtcNow.AddDays(1));
+
+        var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
+        var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
+        Assert.NotNull(created);
+
+        var invalidUpdate = new CreateTaskRequest(
+            "",
+            "Updated Description",
+            "normal",
+            "daily",
+            DateTimeOffset.UtcNow.AddDays(1));
+
+        var response = await _client.PatchAsJsonAsync($"/api/tasks/{created.Id}", invalidUpdate);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Task_endpoint_update_rejects_invalid_priority()
+    {
+        var request = new CreateTaskRequest(
+            "Valid Title",
+            "Valid Description",
+            "normal",
+            "daily",
+            DateTimeOffset.UtcNow.AddDays(1));
+
+        var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
+        var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
+        Assert.NotNull(created);
+
+        var invalidUpdate = new CreateTaskRequest(
+            "Updated Title",
+            "Updated Description",
+            "wrong",
+            "daily",
+            DateTimeOffset.UtcNow.AddDays(1));
+
+        var response = await _client.PatchAsJsonAsync($"/api/tasks/{created.Id}", invalidUpdate);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+
+[Fact]
 public async Task Task_endpoint_deletes_task_successfully()
 {
     var request = new CreateTaskRequest(

--- a/backend-dotnet/OpenLife.Api.Tests/ApiSmokeTests.cs
+++ b/backend-dotnet/OpenLife.Api.Tests/ApiSmokeTests.cs
@@ -72,6 +72,60 @@ public sealed class ApiSmokeTests : IClassFixture<WebApplicationFactory<Program>
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
+    [Fact]
+public async Task Task_endpoint_updates_task_successfully()
+{
+    // Step 1: Create task
+    var request = new CreateTaskRequest(
+        "Test Task",
+        "Test Description",
+        "normal",
+        "daily",
+        DateTimeOffset.UtcNow.AddDays(1));
+
+    var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
+    var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
+    Assert.NotNull(created);
+
+    // Step 2: Update task
+    var updateRequest = new CreateTaskRequest(
+        "Updated Task",
+        "Updated Description",
+        "high",
+        "weekly",
+        DateTimeOffset.UtcNow.AddDays(2));
+
+    var updateResponse = await _client.PatchAsJsonAsync($"/api/tasks/{created.Id}", updateRequest);
+
+    // Step 3: Check result
+    Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+
+    var updated = await updateResponse.Content.ReadFromJsonAsync<TaskResponse>();
+    Assert.NotNull(updated);
+    Assert.Equal("Updated Task", updated.Title);
+}
+
+[Fact]
+public async Task Task_endpoint_deletes_task_successfully()
+{
+    var request = new CreateTaskRequest(
+        "Test Task",
+        "Test Description",
+        "normal",
+        "daily",
+        DateTimeOffset.UtcNow.AddDays(1));
+
+    var createResponse = await _client.PostAsJsonAsync("/api/tasks", request);
+    var created = await createResponse.Content.ReadFromJsonAsync<TaskResponse>();
+    Assert.NotNull(created);
+
+    var deleteResponse = await _client.DeleteAsync($"/api/tasks/{created.Id}");
+
+    Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+
+    var getResponse = await _client.GetAsync($"/api/tasks/{created.Id}");
+    Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+}
     private sealed record HealthResponse(string Status, string Service, DateTimeOffset TimestampUtc);
     private sealed record InfoResponse(string Name, string Backend, string Status, string Purpose);
     private sealed record CreateTaskRequest(string Title, string Description, string Priority, string Period, DateTimeOffset DueDate);

--- a/backend-dotnet/OpenLife.Api/OpenLife.Api.http
+++ b/backend-dotnet/OpenLife.Api/OpenLife.Api.http
@@ -1,6 +1,23 @@
-@OpenLife.Api_HostAddress = http://localhost:5026
+POST http://localhost:5026/api/tasks/
+Content-Type: application/json
 
-GET {{OpenLife.Api_HostAddress}}/weatherforecast/
-Accept: application/json
+{
+  "title": "My Task",
+  "description": "Testing",
+  "priority": "normal",
+  "period": "daily",
+  "dueDate": "2026-05-10T00:00:00Z"
+}
 
 ###
+
+PATCH http://localhost:5026/api/tasks/8de5fddf-ff9a-46a0-9a52-c469163dd9c0
+Content-Type: application/json
+
+{
+  "title": "Updated Task",
+  "description": "Updated description",
+  "priority": "high",
+  "period": "weekly",
+  "dueDate": "2026-05-12T00:00:00Z"
+}

--- a/backend-dotnet/OpenLife.Api/Program.cs
+++ b/backend-dotnet/OpenLife.Api/Program.cs
@@ -62,14 +62,55 @@ tasks.MapGet("/{id:guid}", (Guid id, TaskStore store) =>
 tasks.MapPost("/", (CreateTaskRequest request, TaskStore store) =>
 {
     var validationError = ValidateCreateTask(request);
-    if (validationError is not null)
-    {
-        return Results.BadRequest(new ErrorResponse(validationError));
-    }
+if (validationError is not null)
+{
+    return Results.BadRequest(new ErrorResponse(validationError));
+}
 
     var task = store.Create(request);
     return Results.Created($"/api/tasks/{task.Id}", task);
 });
+
+tasks.MapPatch("/{id:guid}", (Guid id, CreateTaskRequest request, TaskStore store) =>
+{
+    var existingTask = store.Get(id);
+
+    if (existingTask is null)
+    {
+        return Results.NotFound(new ErrorResponse("Task not found."));
+    }
+
+    var updatedTask = new TaskResponse(
+        id,
+        request.Title.Trim(),
+        request.Description.Trim(),
+        existingTask.Status,
+        request.Priority,
+        request.Period,
+        request.DueDate,
+        existingTask.CreatedAtUtc
+    );
+
+    store.Update(id, updatedTask);
+
+    return Results.Ok(updatedTask);
+});
+
+tasks.MapDelete("/{id:guid}", (Guid id, TaskStore store) =>
+{
+    var existingTask = store.Get(id);
+
+    if (existingTask is null)
+    {
+        return Results.NotFound(new ErrorResponse("Task not found."));
+    }
+
+    store.Delete(id);
+
+    return Results.Ok();
+});
+
+
 
 app.Run();
 
@@ -116,6 +157,15 @@ internal static class AllowedValues
 
 internal sealed class TaskStore
 {
+    public void Update(Guid id, TaskResponse task)
+{
+    _tasks[id] = task;
+}
+
+public void Delete(Guid id)
+{
+    _tasks.TryRemove(id, out _);
+}
     private readonly ConcurrentDictionary<Guid, TaskResponse> _tasks = new();
 
     public IReadOnlyCollection<TaskResponse> GetAll()

--- a/backend-dotnet/OpenLife.Api/Program.cs
+++ b/backend-dotnet/OpenLife.Api/Program.cs
@@ -80,6 +80,13 @@ tasks.MapPatch("/{id:guid}", (Guid id, CreateTaskRequest request, TaskStore stor
         return Results.NotFound(new ErrorResponse("Task not found."));
     }
 
+    var validationError = ValidateCreateTask(request);
+
+    if (validationError is not null)
+    {
+        return Results.BadRequest(new ErrorResponse(validationError));
+    }
+    
     var updatedTask = new TaskResponse(
         id,
         request.Title.Trim(),

--- a/backend-dotnet/OpenLife.Api/Program.cs
+++ b/backend-dotnet/OpenLife.Api/Program.cs
@@ -8,25 +8,24 @@ builder.Services.AddOpenApi();
 builder.Services.AddSingleton<TaskStore>();
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy(CorsPolicy, policy =>
-    {
-        var configuredOrigins = builder.Configuration
-            .GetSection("Cors:AllowedOrigins")
-            .Get<string[]>();
+    options.AddPolicy(
+        CorsPolicy,
+        policy =>
+        {
+            var configuredOrigins = builder
+                .Configuration.GetSection("Cors:AllowedOrigins")
+                .Get<string[]>();
 
-        if (configuredOrigins is { Length: > 0 })
-        {
-            policy.WithOrigins(configuredOrigins)
-                .AllowAnyHeader()
-                .AllowAnyMethod();
+            if (configuredOrigins is { Length: > 0 })
+            {
+                policy.WithOrigins(configuredOrigins).AllowAnyHeader().AllowAnyMethod();
+            }
+            else
+            {
+                policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod();
+            }
         }
-        else
-        {
-            policy.AllowAnyOrigin()
-                .AllowAnyHeader()
-                .AllowAnyMethod();
-        }
-    });
+    );
 });
 
 var app = builder.Build();
@@ -38,86 +37,100 @@ if (app.Environment.IsDevelopment())
 
 app.UseCors(CorsPolicy);
 
-app.MapGet("/health", () => new HealthResponse(
-    "ok",
-    "OpenLife.Api",
-    DateTimeOffset.UtcNow));
+app.MapGet("/health", () => new HealthResponse("ok", "OpenLife.Api", DateTimeOffset.UtcNow));
 
-app.MapGet("/api/info", () => new InfoResponse(
-    "OpenLife",
-    "ASP.NET Core",
-    "starter",
-    "Additional backend API for OpenLife contributors and production-readiness work."));
+app.MapGet(
+    "/api/info",
+    () =>
+        new InfoResponse(
+            "OpenLife",
+            "ASP.NET Core",
+            "starter",
+            "Additional backend API for OpenLife contributors and production-readiness work."
+        )
+);
 
 var tasks = app.MapGroup("/api/tasks");
 
 tasks.MapGet("/", (TaskStore store) => Results.Ok(store.GetAll()));
 
-tasks.MapGet("/{id:guid}", (Guid id, TaskStore store) =>
-{
-    var task = store.Get(id);
-    return task is null ? Results.NotFound(new ErrorResponse("Task not found.")) : Results.Ok(task);
-});
-
-tasks.MapPost("/", (CreateTaskRequest request, TaskStore store) =>
-{
-    var validationError = ValidateCreateTask(request);
-if (validationError is not null)
-{
-    return Results.BadRequest(new ErrorResponse(validationError));
-}
-
-    var task = store.Create(request);
-    return Results.Created($"/api/tasks/{task.Id}", task);
-});
-
-tasks.MapPatch("/{id:guid}", (Guid id, CreateTaskRequest request, TaskStore store) =>
-{
-    var existingTask = store.Get(id);
-
-    if (existingTask is null)
+tasks.MapGet(
+    "/{id:guid}",
+    (Guid id, TaskStore store) =>
     {
-        return Results.NotFound(new ErrorResponse("Task not found."));
+        var task = store.Get(id);
+        return task is null
+            ? Results.NotFound(new ErrorResponse("Task not found."))
+            : Results.Ok(task);
     }
+);
 
-    var validationError = ValidateCreateTask(request);
-
-    if (validationError is not null)
+tasks.MapPost(
+    "/",
+    (CreateTaskRequest request, TaskStore store) =>
     {
-        return Results.BadRequest(new ErrorResponse(validationError));
+        var validationError = ValidateCreateTask(request);
+        if (validationError is not null)
+        {
+            return Results.BadRequest(new ErrorResponse(validationError));
+        }
+
+        var task = store.Create(request);
+        return Results.Created($"/api/tasks/{task.Id}", task);
     }
-    
-    var updatedTask = new TaskResponse(
-        id,
-        request.Title.Trim(),
-        request.Description.Trim(),
-        existingTask.Status,
-        request.Priority,
-        request.Period,
-        request.DueDate,
-        existingTask.CreatedAtUtc
-    );
+);
 
-    store.Update(id, updatedTask);
-
-    return Results.Ok(updatedTask);
-});
-
-tasks.MapDelete("/{id:guid}", (Guid id, TaskStore store) =>
-{
-    var existingTask = store.Get(id);
-
-    if (existingTask is null)
+tasks.MapPatch(
+    "/{id:guid}",
+    (Guid id, CreateTaskRequest request, TaskStore store) =>
     {
-        return Results.NotFound(new ErrorResponse("Task not found."));
+        var existingTask = store.Get(id);
+
+        if (existingTask is null)
+        {
+            return Results.NotFound(new ErrorResponse("Task not found."));
+        }
+
+        var validationError = ValidateCreateTask(request);
+
+        if (validationError is not null)
+        {
+            return Results.BadRequest(new ErrorResponse(validationError));
+        }
+
+        var updatedTask = new TaskResponse(
+            id,
+            request.Title.Trim(),
+            request.Description.Trim(),
+            existingTask.Status,
+            request.Priority,
+            request.Period,
+            request.DueDate,
+            existingTask.CreatedAtUtc
+        );
+
+        store.Update(id, updatedTask);
+
+        return Results.Ok(updatedTask);
     }
+);
 
-    store.Delete(id);
+tasks.MapDelete(
+    "/{id:guid}",
+    (Guid id, TaskStore store) =>
+    {
+        var existingTask = store.Get(id);
 
-    return Results.Ok();
-});
+        if (existingTask is null)
+        {
+            return Results.NotFound(new ErrorResponse("Task not found."));
+        }
 
+        store.Delete(id);
 
+        return Results.Ok();
+    }
+);
 
 app.Run();
 
@@ -165,21 +178,20 @@ internal static class AllowedValues
 internal sealed class TaskStore
 {
     public void Update(Guid id, TaskResponse task)
-{
-    _tasks[id] = task;
-}
+    {
+        _tasks[id] = task;
+    }
 
-public void Delete(Guid id)
-{
-    _tasks.TryRemove(id, out _);
-}
+    public void Delete(Guid id)
+    {
+        _tasks.TryRemove(id, out _);
+    }
+
     private readonly ConcurrentDictionary<Guid, TaskResponse> _tasks = new();
 
     public IReadOnlyCollection<TaskResponse> GetAll()
     {
-        return _tasks.Values
-            .OrderByDescending(task => task.CreatedAtUtc)
-            .ToArray();
+        return _tasks.Values.OrderByDescending(task => task.CreatedAtUtc).ToArray();
     }
 
     public TaskResponse? Get(Guid id)
@@ -197,7 +209,8 @@ public void Delete(Guid id)
             request.Priority,
             request.Period,
             request.DueDate,
-            DateTimeOffset.UtcNow);
+            DateTimeOffset.UtcNow
+        );
 
         _tasks[task.Id] = task;
         return task;
@@ -205,9 +218,28 @@ public void Delete(Guid id)
 }
 
 internal sealed record HealthResponse(string Status, string Service, DateTimeOffset TimestampUtc);
+
 internal sealed record InfoResponse(string Name, string Backend, string Status, string Purpose);
-internal sealed record CreateTaskRequest(string Title, string Description, string Priority, string Period, DateTimeOffset DueDate);
-internal sealed record TaskResponse(Guid Id, string Title, string Description, string Status, string Priority, string Period, DateTimeOffset DueDate, DateTimeOffset CreatedAtUtc);
+
+internal sealed record CreateTaskRequest(
+    string Title,
+    string Description,
+    string Priority,
+    string Period,
+    DateTimeOffset DueDate
+);
+
+internal sealed record TaskResponse(
+    Guid Id,
+    string Title,
+    string Description,
+    string Status,
+    string Priority,
+    string Period,
+    DateTimeOffset DueDate,
+    DateTimeOffset CreatedAtUtc
+);
+
 internal sealed record ErrorResponse(string Message);
 
 public partial class Program;


### PR DESCRIPTION
## Summary
- Added PATCH /api/tasks/{id} endpoint to update tasks
- Added DELETE /api/tasks/{id} endpoint to delete tasks
- Implemented update and delete logic in TaskStore
- Added API tests for update and delete functionality

## Type of change
- [x] Feature

## Checklist
- [x] I kept this PR focused on one change
- [x] I ran the relevant checks locally (dotnet test)
- [x] All tests are passing (6/6)

## Notes
- Update returns 200 for existing task and 404 for missing task
- Delete returns 200 for existing task and 404 for missing task