### PR TITLE
fix: resolve #99 — Return 404 when deleting a missing task

### DIFF
--- a/backend/src/tasks/providers/deleteTask.provider.js
+++ b/backend/src/tasks/providers/deleteTask.provider.js
@@ -9,8 +9,11 @@ async function deleteTaskProvider(req, res) {
    * .
    */
  try {
-    const deletedTask = await Task.deleteOne({ _id: req.body["_id"] });
-    res.status(StatusCodes.OK).json(deletedTask);
+    const result = await Task.deleteOne({ _id: req.body["_id"] });
+    if (result.deletedCount === 0) {
+      return res.status(StatusCodes.NOT_FOUND).json({ reason: "Task not found" });
+    }
+    res.status(StatusCodes.OK).json(result);
   } catch (error) {
     errorLogger("Error while deleting task: ", req, error);
     return res.status(StatusCodes.GATEWAY_TIMEOUT).json({


### PR DESCRIPTION
## Summary

fix: resolve #99 — Return 404 when deleting a missing task

## Problem

**Severity**: `Medium` | **File**: `backend/src/tasks/tasks.controller.js`

The controller's `deleteTask` handler currently does not check whether any document was actually deleted. This change adds a conditional that inspects `result.deletedCount` from the provider. If `deletedCount === 0`, it responds with a 404 status and an appropriate error message. If a task was deleted, it responds with a success status (e.g., 200 or 204). This fulfills the issue requirement and gives clients a clear indication of the operation’s outcome.

## Solution

Locate the `deleteTask` handler (typically an async function that calls `deleteTaskProvider`). After obtaining the result, check `result.deletedCount`. Example modification:

## Changes

- `backend/src/tasks/providers/deleteTask.provider.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.8.0*