### PR TITLE
fix: resolve #91 — Add API error response examples to docs

### DIFF
--- a/BACKEND_READINESS.md
+++ b/BACKEND_READINESS.md
@@ -76,6 +76,40 @@ Avoid these as first PRs:
 | Deployment | Add backend deployment guide and environment checklist |
 | Docs | Add API request and error response examples |
 
+## API Error Response Examples
+
+These are fake examples that match the current backend response style as closely as possible.
+
+Validation error (`400`):
+
+```json
+{
+  "errors": [
+    {
+      "msg": "Title is required",
+      "path": "title",
+      "location": "body"
+    }
+  ]
+}
+```
+
+Unauthorized request (`401`):
+
+```json
+{
+  "message": "No token, authorization denied"
+}
+```
+
+Not found route (`404`):
+
+```json
+{
+  "message": "Route not found"
+}
+```
+
 ## Maintainer Review Checklist
 
 Before merging backend PRs, check:


### PR DESCRIPTION
## Summary

fix: resolve #91 — Add API error response examples to docs

## Problem

**Severity**: `Low` | **File**: `BACKEND_READINESS.md`

Add a short documentation section showing fake sample responses for common backend API errors. This satisfies the issue without changing application code. The section should include at least validation error, unauthorized request, and not found route examples, using the current backend response shape as closely as possible based on existing controllers, validators, and middleware.

## Solution

Add a new section such as `## API Error Response Examples` near the existing backend/API documentation. Include concise examples for:

## Changes

- `BACKEND_READINESS.md` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Contributed by Lê Thành Chỉnh*