### PR TITLE
fix: resolve #97 — Fix task query validation defaults and order values

### DIFF
--- a/backend/src/tasks/providers/getTask.provider.js
+++ b/backend/src/tasks/providers/getTask.provider.js
@@ -59,7 +59,7 @@ async function getTasksProvider(req, res) {
       .limit(limit)
       .skip(skip)
       .sort({
-        createdAt: order === "asc" ? 1 : -1,
+        createdAt: order === "desc" ? -1 : 1,
       });
 
  

--- a/backend/src/tasks/validators/getTasks.validator.js
+++ b/backend/src/tasks/validators/getTasks.validator.js
@@ -9,18 +9,16 @@ const getTasksValidator = [
   query("page").customSanitizer((value) => {
     return value ? value : 1; // default skip/page is 1 if not provided
   }),
-  query("order", "order must be one of ['asc', 'dsc']")
+  query("order", "order must be one of ['asc', 'desc']")
     .optional()
-    .isIn(["asc", "dsc"]),
+    .isIn(["asc", "desc"]),
     query("order").customSanitizer((value) => {
     return value ? value : "asc"; // default order is asc if not provided
   }),
   query("period", "period must be one of ['daily', 'weekly', 'monthly', 'yearly']")
     .optional()
     .isIn(["daily", "monthly", "weekly", "yearly"]),
-    query("order").customSanitizer((value) => {
-    return value ? value : "daily"; // default order is asc if not provided
-  }),
+
 ];
 
 module.exports = getTasksValidator;

--- a/backend/src/tasks/validators/getTasks.validator.test.js
+++ b/backend/src/tasks/validators/getTasks.validator.test.js
@@ -1,0 +1,62 @@
+const { matchedData, validationResult } = require("express-validator");
+const getTasksValidator = require("./getTasks.validator.js");
+
+async function validate(query = {}) {
+  const req = { query };
+
+  await Promise.all(getTasksValidator.map((validator) => validator.run(req)));
+
+  return {
+    data: matchedData(req),
+    errors: validationResult(req),
+  };
+}
+
+describe("getTasksValidator", () => {
+  it("defaults missing order to asc", async () => {
+    const result = await validate();
+
+    expect(result.errors.isEmpty()).toBe(true);
+    expect(result.data.order).toBe("asc");
+  });
+
+  it("allows asc order", async () => {
+    const result = await validate({ order: "asc" });
+
+    expect(result.errors.isEmpty()).toBe(true);
+    expect(result.data.order).toBe("asc");
+  });
+
+  it("allows desc order", async () => {
+    const result = await validate({ order: "desc" });
+
+    expect(result.errors.isEmpty()).toBe(true);
+    expect(result.data.order).toBe("desc");
+  });
+
+  it("rejects dsc order", async () => {
+    const result = await validate({ order: "dsc" });
+
+    expect(result.errors.isEmpty()).toBe(false);
+  });
+
+  it("rejects invalid order", async () => {
+    const result = await validate({ order: "invalid" });
+
+    expect(result.errors.isEmpty()).toBe(false);
+  });
+
+  it("allows provided period", async () => {
+    const result = await validate({ period: "weekly" });
+
+    expect(result.errors.isEmpty()).toBe(true);
+    expect(result.data.period).toBe("weekly");
+  });
+
+  it("does not default missing period", async () => {
+    const result = await validate();
+
+    expect(result.errors.isEmpty()).toBe(true);
+    expect(result.data.period).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

fix: resolve #97 — Fix task query validation defaults and order values

## Problem

**Severity**: `High` | **File**: `backend/src/tasks/validators/getTasks.validator.js`

Update the query validator so it accepts the same order values that the task provider expects. The current validator reportedly accepts `dsc`, but the provider checks for `desc`, causing `order=desc` to fail validation or not behave consistently. Also fix the duplicated `order` sanitization/default logic so `period` is not accidentally defaulted or overwritten incorrectly.

## Solution

Review the validator middleware/schema for query params such as `page`, `limit`, `order`, and `period`. Change allowed order values to exactly `asc` and `desc`. Keep the default order as `asc` when `order` is missing. Remove any duplicate sanitizer/default call that applies to `order` twice. If `period` is optional, do not assign a default value to it; only validate/sanitize it when the client provides it. Ensure invalid values like `order=dsc`, `order=descending`, or `order=random` return validation errors. Example intent: `order` should be optional with default `asc`, while `period` should be optional without a forced default.

## Changes

- `backend/src/tasks/validators/getTasks.validator.js` (modified)
- `backend/src/tasks/providers/getTask.provider.js` (modified)
- `backend/src/tasks/validators/getTasks.validator.test.js` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Contributed by Lê Thành Chỉnh*