### PR TITLE
docs: add placeholder auth API examples

### DIFF
--- a/backend/src/auth/http/post.login.endpoints.http
+++ b/backend/src/auth/http/post.login.endpoints.http
@@ -3,5 +3,5 @@ Content-Type: application/json
 
 {
   "email": "user@example.com",
-  "password": "ExamplePassword123!"
+  "password": "REPLACE_WITH_PASSWORD"
 }

--- a/backend/src/auth/http/post.login.endpoints.http
+++ b/backend/src/auth/http/post.login.endpoints.http
@@ -2,6 +2,6 @@ POST http://localhost:3001/login
 Content-Type: application/json
 
 {
-    "email": "chandandeep95012@gmail.com",
-    "password": "131002@Cb"
+  "email": "user@example.com",
+  "password": "ExamplePassword123!"
 }

--- a/backend/src/users/http/post.create.endpoints.http
+++ b/backend/src/users/http/post.create.endpoints.http
@@ -5,5 +5,5 @@ Content-Type: application/json
   "firstname": "John",
   "lastname": "Doe",
   "email": "user@example.com",
-  "password": "ExamplePassword123!"
+  "password": "REPLACE_WITH_PASSWORD"
 }

--- a/backend/src/users/http/post.create.endpoints.http
+++ b/backend/src/users/http/post.create.endpoints.http
@@ -2,8 +2,8 @@ POST http://localhost:3001/users/create
 Content-Type: application/json
 
 {
-  "firstname": "PB",
-  "lastname": "Karan",  
- "email": "pbkaran999@gmail.com",
-  "password": "Karan@123"
+  "firstname": "John",
+  "lastname": "Doe",
+  "email": "user@example.com",
+  "password": "ExamplePassword123!"
 }


### PR DESCRIPTION
## Summary

Updates authentication HTTP example files to use placeholder credentials instead of real-looking personal information.

## Type of change

* [x] Documentation

## Checklist

* [x] I kept this PR focused on one change.
* [x] I updated docs or examples when behavior changed.
* [x] I linked the related issue, if one exists.

Closes #84

## Notes

This PR:

* Updates login API examples
* Updates signup API examples
* Replaces real-looking email addresses and passwords
* Uses placeholder credentials
* Keeps backend example files organized
