### PR TITLE
docs: add placeholder auth API examples

### DIFF
--- a/backend/src/auth/http/post.login.endpoints.http
+++ b/backend/src/auth/http/post.login.endpoints.http
@@ -2,6 +2,6 @@ POST http://localhost:3001/login
 Content-Type: application/json
 
 {
-    "email": "chandandeep95012@gmail.com",
-    "password": "131002@Cb"
+  "email": "user@example.com",
+  "password": "REPLACE_WITH_PASSWORD"
 }

--- a/backend/src/users/http/post.create.endpoints.http
+++ b/backend/src/users/http/post.create.endpoints.http
@@ -2,8 +2,8 @@ POST http://localhost:3001/users/create
 Content-Type: application/json
 
 {
-  "firstname": "PB",
-  "lastname": "Karan",  
- "email": "pbkaran999@gmail.com",
-  "password": "Karan@123"
+  "firstname": "John",
+  "lastname": "Doe",
+  "email": "user@example.com",
+  "password": "REPLACE_WITH_PASSWORD"
 }


### PR DESCRIPTION
### Summary
Replaces real-looking credentials in the authentication and user creation HTTP example files with generic placeholder values to ensure security and prevent the inclusion of personal/mock credentials.

### What changed
- Updated [post.login.endpoints.http](backend/src/auth/http/post.login.endpoints.http) to use `"user@example.com"` and `"REPLACE_WITH_PASSWORD"`.
- Updated [post.create.endpoints.http](backend/src/users/http/post.create.endpoints.http) to use `"John"`, `"Doe"`, `"user@example.com"`, and `"REPLACE_WITH_PASSWORD"`.

### Why it matters
API examples should not contain any real-looking emails or credentials, aligning with best practices and codebase security.

### Checklist
- [x] I kept this PR focused on one change.
- [x] I updated docs or examples when behavior changed.
- [x] I linked the related issue, if one exists.

Closes #84
