### PR TITLE
chore: remove backend startup debug logs

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -12,14 +12,8 @@ const envFile = `.env.${process.env.NODE_ENV}`;
 // configure dotenv earlier in application
 dotenv.config({ path: envFile });
 
-// !Test FIRST SEE CONFIG WITHOUT PATH
-console.log(process.env.TEST_VARIABLE);
-
-
 const app = express();
 const port = parseInt(process.env.PORT) || 3001;
-
-console.log(process.env.NODE_ENV);
 
 //  Parsing request body
 app.use(express.json());

--- a/backend/src/settings/config.js
+++ b/backend/src/settings/config.js
@@ -59,7 +59,6 @@ app.use("/", taskRouter);
 
 
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpecs));
-console.log(swaggerSpecs);
 
 // send back a 404 error for any unknown api request
 // Sequence is important


### PR DESCRIPTION
## Summary

Removes startup debug logging from the backend:

- `src/index.js` — dropped `console.log(process.env.TEST_VARIABLE)` (plus its now-dangling `!Test` comment) and `console.log(process.env.NODE_ENV)`
- `src/settings/config.js` — dropped `console.log(swaggerSpecs)`, which dumped the entire generated OpenAPI spec to stdout on every boot

Kept the `Connnected To MongoDB` and `App listening on port` messages as the issue specifies, and left `console.error` in the catch block untouched.

Closes #89

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Maintenance

## Checklist

- [x] I kept this PR focused on one change.
- [x] I ran the relevant checks locally.
- [x] I updated docs or examples when behavior changed.
- [x] I linked the related issue, if one exists.

## Screenshots or notes

`npm test` passes from `backend/`: **12 passing, 0 failing**.

Verified nothing prints before the DB connection attempt at startup — previously the env values and full swagger spec were emitted first.

Request-time `console.log` calls remain in `auth.router.js`, `tasks.router.js`, and `createTask.provider.js`. Left out as this issue scopes to startup — happy to handle them in a follow-up.

Minor: the kept DB message has a typo ("Connnected"). Left as-is to keep the diff focused — glad to fix if preferred.
